### PR TITLE
Add CI workflow and configuration-bound API skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        dotnet-version: ['8.0.x']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
+      - name: Restore
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+      - name: Test
+        run: dotnet test --no-build --configuration Release

--- a/src/MediaMtx.Net.HttpApi/ApiOptions.cs
+++ b/src/MediaMtx.Net.HttpApi/ApiOptions.cs
@@ -1,0 +1,6 @@
+namespace MediaMtx.Net.HttpApi;
+
+public sealed record ApiOptions
+{
+    public required string Greeting { get; init; }
+}

--- a/src/MediaMtx.Net.HttpApi/Program.cs
+++ b/src/MediaMtx.Net.HttpApi/Program.cs
@@ -1,17 +1,20 @@
+using MediaMtx.Net.HttpApi;
+using Microsoft.Extensions.Options;
 using Prometheus;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddHealthChecks();
+builder.Services.Configure<ApiOptions>(builder.Configuration.GetSection("Api"));
 
 var app = builder.Build();
 
 app.UseHttpMetrics();
 
-app.MapGet("/", (ILogger<Program> logger) =>
+app.MapGet("/", (ILogger<Program> logger, IOptions<ApiOptions> options) =>
 {
     logger.LogInformation("Root endpoint called");
-    return Results.Ok(new { message = "MediaMTX.Net API" });
+    return Results.Ok(new { message = options.Value.Greeting });
 });
 
 app.MapHealthChecks("/healthz");

--- a/src/MediaMtx.Net.HttpApi/appsettings.Development.json
+++ b/src/MediaMtx.Net.HttpApi/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Api": {
+    "Greeting": "MediaMTX.Net API"
   }
 }

--- a/src/MediaMtx.Net.HttpApi/appsettings.json
+++ b/src/MediaMtx.Net.HttpApi/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Api": {
+    "Greeting": "MediaMTX.Net API"
+  }
 }

--- a/tests/Unit/MediaMtx.Net.HttpApi.Tests/RootEndpointTests.cs
+++ b/tests/Unit/MediaMtx.Net.HttpApi.Tests/RootEndpointTests.cs
@@ -1,0 +1,25 @@
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace MediaMtx.Net.HttpApi.Tests;
+
+public class RootEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public RootEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Root_ReturnsConfiguredMessage()
+    {
+        var response = await _client.GetFromJsonAsync<ApiResponse>("/");
+        response.Should().NotBeNull();
+        response!.Message.Should().Be("MediaMTX.Net API");
+    }
+
+    private sealed record ApiResponse(string Message);
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test on Linux and Windows
- configure API greeting via options and expose through root endpoint
- cover root endpoint with a unit test

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6899cd70c03c8330a1b13fa368ea259b